### PR TITLE
Ensure sys.exit() is noisy.

### DIFF
--- a/simulators/extras/ArgumentsAndCredentialsHandler.py
+++ b/simulators/extras/ArgumentsAndCredentialsHandler.py
@@ -129,7 +129,7 @@ def HandleImportArguments():
 
     if not os.path.exists("export_data"):
         logging.info("No export_data folder found")
-        sys.exit()
+        sys.exit(1)
     INPUT_FILE_LIST = args.ifiles
     if not INPUT_FILE_LIST:
         INPUT_FILE_LIST = []

--- a/simulators/extras/ExportProfileData.py
+++ b/simulators/extras/ExportProfileData.py
@@ -28,7 +28,7 @@ else:
     else:
         consoleLogger.error(tenantConnectionResponse.json())
     consoleLogger.error(f"Connect to tenant {c8y.tenant_id} failed")
-    sys.exit()
+    sys.exit(1)
 ######################################################
 
 
@@ -86,13 +86,13 @@ def FindDeviceNameById(deviceId, baseUrl):
                             headers=C8Y_HEADERS)
     if not response.ok:
         consoleLogger.error(response.json())
-        sys.exit()
+        sys.exit(1)
     else:
         try:
             deviceName = response.json()['name']
         except:
             consoleLogger.error(f"Device #{deviceId} does not have name")
-            sys.exit()
+            sys.exit(1)
 
     return deviceName
 
@@ -135,7 +135,7 @@ def GetExternalIdReponse(deviceId, baseUrl):
                                       headers=C8Y_HEADERS)
     if not externalIdResponse.ok:
         consoleLogger.error(externalIdResponse.json())
-        sys.exit()
+        sys.exit(1)
     else:
         return externalIdResponse
 

--- a/simulators/extras/ImportData.py
+++ b/simulators/extras/ImportData.py
@@ -30,7 +30,7 @@ else:
     else:
         consoleLogger.error(tenantConnectionResponse.json())
     consoleLogger.error(f"Connection to tenant \"{c8y.tenant_id}\" failed with user {c8y.username} on {c8y.base_url}")
-    sys.exit()
+    sys.exit(1)
 ######################################################
 
 


### PR DESCRIPTION
Make sure that when Import/Export tool fails, it sets the error code to a non-zero value, otherwise the parent process will assume everything is fine. This is super important for internal CI/CD pipe.

NB: There is another call to sys.exit() in the main Simulator code. I have not touched this but we may wish to do so. 