### PR TITLE
COE-823: send the first measurement right after start

### DIFF
--- a/simulators/main/measurement.py
+++ b/simulators/main/measurement.py
@@ -13,6 +13,7 @@ class Measurement(interface.MachineType):
         self.model = model
         self.definitions = self.model.get('measurements', [])
         self.simulated_data = {}
+        self.first_time = True
 
     def callback(self, definition, min_interval_in_seconds, max_interval_in_seconds):
         measurement_callback = lambda task: {self.measurement_functions(definition, task)}

--- a/simulators/main/simulators.py
+++ b/simulators/main/simulators.py
@@ -1,5 +1,7 @@
 import sys
 import time, json, os, logging
+from datetime import datetime
+
 from cumulocityAPI import (C8Y_BASE, C8Y_TENANT, C8Y_USER, CumulocityAPI)
 from oeeAPI import OeeAPI, ProfileCreateMode
 from shiftplan import Shiftplan
@@ -61,6 +63,13 @@ class MachineSimulator:
             return
         if self.machine.should_tick():
             for task in self.machine.tasks:
+                try:
+                    if self.machine.first_time:
+                        # set the next_run time to always let the measurement generation to run in the first time
+                        task.next_run = datetime.timestamp(datetime.utcnow()) + 1
+                        self.machine.first_time = False
+                except:
+                    pass
                 if task:
                     task.tick()
 


### PR DESCRIPTION
Set the measurement machine first time next_run to be always bigger than current timestamps so the generation always works the first time